### PR TITLE
point the module to main script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "database",
     "store"
   ],
+  "main": "build/Release/qdb.node",
   "version": "2.0.0beta3",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change is required so we could `require('qdb')` 
