### PR TITLE
Fix build from source when using as direct dependency

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "copy_c_api": "no"
+  },
   "targets": [
     {
       "target_name": "<(module_name)",
@@ -152,8 +155,17 @@
               {
                 "destination": "<(module_path)",
                 "files": [
-                  "<(PRODUCT_DIR)/<(module_name).node",
-                  "<(module_root_dir)/qdb/lib/libqdb_api.dylib"
+                  "<(PRODUCT_DIR)/<(module_name).node"
+                ],
+                "conditions": [
+                  [
+                    "copy_c_api=='yes'",
+                    {
+                      "files": [
+                        "<(module_root_dir)/qdb/lib/libqdb_api.dylib"
+                      ]
+                    }
+                  ]
                 ]
               }
             ]
@@ -166,8 +178,17 @@
               {
                 "destination": "<(module_path)",
                 "files": [
-                  "<(PRODUCT_DIR)/<(module_name).node",
-                  "<(module_root_dir)/qdb/lib/libqdb_api.so"
+                  "<(PRODUCT_DIR)/<(module_name).node"
+                ],
+                "conditions": [
+                  [
+                    "copy_c_api=='yes'",
+                    {
+                      "files": [
+                        "<(module_root_dir)/qdb/lib/libqdb_api.so"
+                      ]
+                    }
+                  ]
                 ]
               }
             ]
@@ -180,8 +201,17 @@
               {
                 "destination": "<(module_path)",
                 "files": [
-                  "<(PRODUCT_DIR)/<(module_name).node",
-                  "<(module_root_dir)/qdb/bin/qdb_api.dll"
+                  "<(PRODUCT_DIR)/<(module_name).node"
+                ],
+                "conditions": [
+                  [
+                    "copy_c_api=='yes'",
+                    {
+                      "files": [
+                        "<(module_root_dir)/qdb/bin/qdb_api.dll"
+                      ]
+                    }
+                  ]
                 ]
               }
             ]


### PR DESCRIPTION
The problem with the current build settings is that it assumes that the user has the c api in the qdb folder, which works when we are make a prebuilt binary on team city but not when the user is using it as a direct npm dependency.

I've added a variable called `copy_c_api` which will determine when to copy the library and is by default false. This means when someone installs it as a dependency and there is no binary available the build works provided they have the c api installed and the library available on their path.

As for pre-building node binaries we simply need to add an additional --copy_c_api=yes to the build step